### PR TITLE
Switch to @xmldom/xmldom to address security advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module provides a [jQuery](http://jquery.com/)-like wrapper, but geared for
 traversing and manipulating an XML DOM, as opposeed to an HTML DOM.  The API
 aims to be compatible with [Strophe.js](https://github.com/strophe/strophejs)'
 `Builder` and [Less-Than XML](https://github.com/astro/ltx).  The underlying DOM
-is W3C standard, provided by [XMLDOM](https://github.com/jindw/xmldom).
+is W3C standard, provided by [XMLDOM](https://github.com/xmldom/xmldom).
 
 ## Install
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var dom = require('xmldom')
+var dom = require('@xmldom/xmldom')
   , DOMParser = dom.DOMParser
   , XMLSerializer = dom.XMLSerializer;
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "xmldom": "0.1.x"
+    "@xmldom/xmldom": "^0.7.5"
   },
   "devDependencies": {
     "mocha": "1.x.x",
@@ -45,7 +45,7 @@
     "browsers": [
       "chrome/latest"
     ],
-    "harness" : "mocha",
+    "harness": "mocha",
     "files": [
       "test/bootstrap/testling.js",
       "test/*.test.js"

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-  , DOMParser = require('xmldom').DOMParser
+  , DOMParser = require('@xmldom/xmldom').DOMParser
   , $ = require('..');
 
 


### PR DESCRIPTION
New versions of xmldom are published as @xmldom/xmldom. [Announcement and reasoning](https://github.com/xmldom/xmldom/issues/271)

The security advisories highlighted by `npm audit --production` for this package are addressed by this PR. This also affects packages like `twitter-passport` that depend on `xtraverse`.

Please let me know if there is anything else I can do to get this fix merged.